### PR TITLE
fix typo when calling `resize2fs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I tried this all on a Raspberry Pi 4.
 
 2. `resizepart 3` will resize your partition. When it asked for the end I just did 128GB which was from the output of the earlier `print free` command. Make sure to `quit` to save your changes.
 
-3. Run `resize2fs /dev/mmblk0p3` and then `df -h` and you should now see you have more room to download packages to your hearts content.
+3. Run `resize2fs /dev/mmcblk0p3` and then `df -h` and you should now see you have more room to download packages to your hearts content.
 
 **Bonus Round**: Getting GNOME working.
 **NOTE**: If you enable GNOME, networking will need to reconfigured. See https://github.com/raspberrypi/linux/issues/4393


### PR DESCRIPTION
Everything went smoothly when installing Alma on my raspi 4b until I got the `resize2fs` command after setting it to expand I was getting the following error:

```bash
[root@localhost ~]# sudo resize2fs /dev/mmblk0p3
resize2fs 1.45.6 (20-Mar-2020)
open: No such file or directory while opening /dev/mmblk0p3```

so I went it my `/dev` directory and it looked like there was a typo:

```bash
[root@localhost ~]# cd /dev
[root@localhost dev]# ls
autofs         cpu_dma_latency  gpiochip0  kvm    loop5         mem        null  ram10  ram3  random          shm     tty1   tty16  tty22  tty29  tty35  tty41  tty48  tty54  tty60  ttyAMA0    vcio    vcs5   vcsa5     vcsu4        video11   watchdog0
block          cuse             gpiochip1  log    loop6         mmcblk0    port  ram11  ram4  raw             snd     tty10  tty17  tty23  tty3   tty36  tty42  tty49  tty55  tty61  ttyprintk  vc-mem  vcs6   vcsa6     vcsu5        video12   zero
btrfs-control  disk             gpiomem    loop0  loop7         mmcblk0p1  ppp   ram12  ram5  rfkill          stderr  tty11  tty18  tty24  tty30  tty37  tty43  tty5   tty56  tty62  uhid       vcs     vcsa   vcsm-cma  vcsu6        video13
bus            dma_heap         hwrng      loop1  loop-control  mmcblk0p2  ptmx  ram13  ram6  rpivid-h264mem  stdin   tty12  tty19  tty25  tty31  tty38  tty44  tty50  tty57  tty63  uinput     vcs1    vcsa1  vcsu      vga_arbiter  video14
cachefiles     fd               initctl    loop2  mapper        mmcblk0p3  pts   ram14  ram7  rpivid-hevcmem  stdout  tty13  tty2   tty26  tty32  tty39  tty45  tty51  tty58  tty7   urandom    vcs2    vcsa2  vcsu1     vhci         video15
char           full             input      loop3  media0        mqueue     ram0  ram15  ram8  rpivid-intcmem  tty     tty14  tty20  tty27  tty33  tty4   tty46  tty52  tty59  tty8   v4l        vcs3    vcsa3  vcsu2     vhost-net    video16
console        fuse             kmsg       loop4  media1        net        ram1  ram2   ram9  rpivid-vp9mem   tty0    tty15  tty21  tty28  tty34  tty40  tty47  tty53  tty6   tty9   vchiq      vcs4    vcsa4  vcsu3     video10      watchdog```

so I tried with mm**c**blk0p3 instead and it worked :)

```bash
[root@localhost dev]# sudo resize2fs /dev/mmcblk0p3
resize2fs 1.45.6 (20-Mar-2020)
Filesystem at /dev/mmcblk0p3 is mounted on /; on-line resizing required
old_desc_blocks = 1, new_desc_blocks = 15
The filesystem on /dev/mmcblk0p3 is now 31017984 (4k) blocks long.

[root@localhost dev]# df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       117G  1.6G  115G   2% /
devtmpfs        3.8G     0  3.8G   0% /dev
tmpfs           3.9G     0  3.9G   0% /dev/shm
tmpfs           3.9G   25M  3.8G   1% /run
tmpfs           3.9G     0  3.9G   0% /sys/fs/cgroup
/dev/mmcblk0p1  286M   66M  221M  23% /boot
tmpfs           782M     0  782M   0% /run/user/0```