### PR TITLE
Allow root SSH login with password and add motd with reminder to change it

### DIFF
--- a/AlmaLinux-8-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-console.aarch64.ks
@@ -60,6 +60,16 @@ rootfs-expand
 
 EOF
 
+# root password change motd
+cat >/etc/motd << EOF
+It's highly recommended to change root password by typing the following:
+passwd
+
+To remove this message:
+>/etc/motd
+
+EOF
+
 cat > /boot/config.txt << EOF
 # AlmaLinux doesn't use any default config options to work,
 # this file is provided as a placeholder for user options

--- a/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
@@ -67,6 +67,16 @@ rootfs-expand
 
 EOF
 
+# root password change motd
+cat >/etc/motd << EOF
+It's highly recommended to change root password by typing the following:
+passwd
+
+To remove this message:
+>/etc/motd
+
+EOF
+
 cat > /boot/config.txt << EOF
 # This file is provided as a placeholder for user options
 # AlmaLinux - few default config options for better graphics support

--- a/AlmaLinux-9-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-console.aarch64.ks
@@ -60,6 +60,19 @@ rootfs-expand
 
 EOF
 
+# root password change motd
+cat >/etc/motd << EOF
+It's highly recommended to change root password by typing the following:
+passwd
+
+To remove this message:
+>/etc/motd
+
+EOF
+
+# Allow root SSH login with password
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
 cat > /boot/config.txt << EOF
 # AlmaLinux doesn't use any default config options to work,
 # this file is provided as a placeholder for user options

--- a/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
@@ -67,6 +67,19 @@ rootfs-expand
 
 EOF
 
+# root password change motd
+cat >/etc/motd << EOF
+It's highly recommended to change root password by typing the following:
+passwd
+
+To remove this message:
+>/etc/motd
+
+EOF
+
+# Allow root SSH login with password
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
 cat > /boot/config.txt << EOF
 # This file is provided as a placeholder for user options
 # AlmaLinux - few default config options for better graphics support


### PR DESCRIPTION
This will show the following message on SSH login:
```
It's highly recommended to change root password by typing the following:
passwd

To remove this message:
>/etc/motd
```
Also root SSH login with password will be allowed on AlmaLinux 9.
Fixes: https://github.com/AlmaLinux/raspberry-pi/issues/16

This can be temporary solution until we implement Raspberry PI OS compatible solution mentioned in https://github.com/AlmaLinux/raspberry-pi/issues/13