### PR TITLE
Set default password for GNOME login

### DIFF
--- a/AlmaLinux-8-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-console.aarch64.ks
@@ -85,7 +85,7 @@ EOF
 # Data sources for cloud-init
 touch /boot/meta-data /boot/user-data
 
-cat >/boot/user-data << EOF
+cat >/boot/user-data << "EOF"
 #cloud-config
 #
 # This is default cloud-init config file for AlmaLinux Raspberry Pi image.
@@ -103,6 +103,8 @@ users:
   - name: almalinux
     groups: [ adm, systemd-journal ]
     sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    lock_passwd: false
+    passwd: $6$EJCqLU5JAiiP5iSS$wRmPHYdotZEXa8OjfcSsJ/f1pAYTk0/OFHV1CGvcszwmk6YwwlZ/Lwg8nqjRT0SSKJIMh/3VuW5ZBz2DqYZ4c1
     ssh_authorized_keys:
       # Put here your ssh public keys
       #- ssh-ed25519 AAAAC3Nz...

--- a/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
@@ -92,7 +92,7 @@ EOF
 # Data sources for cloud-init
 touch /boot/meta-data /boot/user-data
 
-cat >/boot/user-data << EOF
+cat >/boot/user-data << "EOF"
 #cloud-config
 #
 # This is default cloud-init config file for AlmaLinux Raspberry Pi image.
@@ -110,6 +110,8 @@ users:
   - name: almalinux
     groups: [ adm, systemd-journal ]
     sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    lock_passwd: false
+    passwd: $6$EJCqLU5JAiiP5iSS$wRmPHYdotZEXa8OjfcSsJ/f1pAYTk0/OFHV1CGvcszwmk6YwwlZ/Lwg8nqjRT0SSKJIMh/3VuW5ZBz2DqYZ4c1
     ssh_authorized_keys:
       # Put here your ssh public keys
       #- ssh-ed25519 AAAAC3Nz...

--- a/AlmaLinux-9-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-console.aarch64.ks
@@ -69,7 +69,7 @@ EOF
 # Data sources for cloud-init
 touch /boot/meta-data /boot/user-data
 
-cat >/boot/user-data << EOF
+cat >/boot/user-data << "EOF"
 #cloud-config
 #
 # This is default cloud-init config file for AlmaLinux Raspberry Pi image.
@@ -87,6 +87,8 @@ users:
   - name: almalinux
     groups: [ adm, systemd-journal ]
     sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    lock_passwd: false
+    passwd: $6$EJCqLU5JAiiP5iSS$wRmPHYdotZEXa8OjfcSsJ/f1pAYTk0/OFHV1CGvcszwmk6YwwlZ/Lwg8nqjRT0SSKJIMh/3VuW5ZBz2DqYZ4c1
     ssh_authorized_keys:
       # Put here your ssh public keys
       #- ssh-ed25519 AAAAC3Nz...

--- a/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
@@ -76,7 +76,7 @@ EOF
 # Data sources for cloud-init
 touch /boot/meta-data /boot/user-data
 
-cat >/boot/user-data << EOF
+cat >/boot/user-data << "EOF"
 #cloud-config
 #
 # This is default cloud-init config file for AlmaLinux Raspberry Pi image.
@@ -94,6 +94,8 @@ users:
   - name: almalinux
     groups: [ adm, systemd-journal ]
     sudo: [ "ALL=(ALL) NOPASSWD:ALL" ]
+    lock_passwd: false
+    passwd: $6$EJCqLU5JAiiP5iSS$wRmPHYdotZEXa8OjfcSsJ/f1pAYTk0/OFHV1CGvcszwmk6YwwlZ/Lwg8nqjRT0SSKJIMh/3VuW5ZBz2DqYZ4c1
     ssh_authorized_keys:
       # Put here your ssh public keys
       #- ssh-ed25519 AAAAC3Nz...


### PR DESCRIPTION
For consistency, set the same default password for console images.

----

I decided to set default password to default almalinux user for GNOME login.

Because `gnome-initial-setup`  is only ignited if users (uid >=1000) does not exist but cloud-init automatically creates default user. I have created a wiki page for cloud-init documentation.
https://github.com/AlmaLinux/raspberry-pi/wiki/How-to-use-cloud-init-to-configure-image