### PR TITLE
Remove "elevator=deadline" on kernel cmdline

### DIFF
--- a/AlmaLinux-8-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-console.aarch64.ks
@@ -118,7 +118,7 @@ EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait
+console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
@@ -134,7 +134,7 @@ EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait
+console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/AlmaLinux-9-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-console.aarch64.ks
@@ -102,7 +102,7 @@ EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait
+console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
@@ -118,7 +118,7 @@ EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait
+console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile


### PR DESCRIPTION
The current standard is mq-deadline - which is okay - so there is no need for this extra setting.