### PR TITLE
Add [all] filter at the bottom of config.txt

### DIFF
--- a/AlmaLinux-8-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-console.aarch64.ks
@@ -114,6 +114,8 @@ EOF
 cat > /boot/config.txt << EOF
 # AlmaLinux doesn't use any default config options to work,
 # this file is provided as a placeholder for user options
+
+[all]
 EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3

--- a/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
@@ -127,9 +127,11 @@ dtoverlay=vc4-kms-v3d
 camera_auto_detect=0
 gpu_mem=64
 
-## AlmaLinux - can enable this for Pi 4 and later
+## AlmaLinux - can enable this for Pi 4
 #[pi4]
 #max_framebuffers=2
+
+[all]
 EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3

--- a/AlmaLinux-9-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-console.aarch64.ks
@@ -98,6 +98,8 @@ EOF
 cat > /boot/config.txt << EOF
 # AlmaLinux doesn't use any default config options to work,
 # this file is provided as a placeholder for user options
+
+[all]
 EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3

--- a/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
@@ -111,9 +111,11 @@ dtoverlay=vc4-kms-v3d
 camera_auto_detect=0
 gpu_mem=64
 
-## AlmaLinux - can enable this for Pi 4 and later
+## AlmaLinux - can enable this for Pi 4
 #[pi4]
 #max_framebuffers=2
+
+[all]
 EOF
 
 # Specific cmdline.txt files needed for raspberrypi2/3


### PR DESCRIPTION
It is recommended in documentation:

> It is usually a good idea to add an [all] filter at the end of groups
> of filtered settings to avoid unintentionally combining filters (see
> below).

https://www.raspberrypi.com/documentation/computers/config_txt.html#the-all-filter

Pointed out by @akkiesoft, thanks!