### PR TITLE
Adjust configuration to get serial console working properly

### DIFF
--- a/AlmaLinux-8-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-console.aarch64.ks
@@ -114,15 +114,17 @@ users:
 EOF
 
 cat > /boot/config.txt << EOF
-# AlmaLinux doesn't use any default config options to work,
-# this file is provided as a placeholder for user options
+# This file is provided as a placeholder for user options
+# AlmaLinux - few default config options
 
 [all]
+# enable serial console
+enable_uart=1
 EOF
 
-# Specific cmdline.txt files needed for raspberrypi2/3
+# Kernel command line string
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
+console=ttyS0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-8-RaspberryPi-gnome.aarch64.ks
@@ -128,6 +128,8 @@ disable_overscan=1
 dtoverlay=vc4-kms-v3d
 camera_auto_detect=0
 gpu_mem=128
+# enable serial console
+enable_uart=1
 
 ## AlmaLinux - can enable this for Pi 4
 #[pi4]
@@ -136,9 +138,9 @@ gpu_mem=128
 [all]
 EOF
 
-# Specific cmdline.txt files needed for raspberrypi2/3
+# Kernel command line string
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
+console=ttyS0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/AlmaLinux-9-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-console.aarch64.ks
@@ -98,15 +98,17 @@ users:
 EOF
 
 cat > /boot/config.txt << EOF
-# AlmaLinux doesn't use any default config options to work,
-# this file is provided as a placeholder for user options
+# This file is provided as a placeholder for user options
+# AlmaLinux - few default config options
 
 [all]
+# enable serial console
+enable_uart=1
 EOF
 
-# Specific cmdline.txt files needed for raspberrypi2/3
+# Kernel command line string
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
+console=ttyS0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/AlmaLinux-9-RaspberryPi-console.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-console.aarch64.ks
@@ -53,6 +53,7 @@ raspberrypi-userland
 raspberrypi2-firmware
 raspberrypi2-kernel4
 nano
+libgpiod-utils
 %end
 
 %post

--- a/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
@@ -60,6 +60,7 @@ raspberrypi-userland
 raspberrypi2-firmware
 raspberrypi2-kernel4
 nano
+libgpiod-utils
 %end
 
 %post

--- a/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
+++ b/AlmaLinux-9-RaspberryPi-gnome.aarch64.ks
@@ -112,6 +112,8 @@ disable_overscan=1
 dtoverlay=vc4-kms-v3d
 camera_auto_detect=0
 gpu_mem=128
+# enable serial console
+enable_uart=1
 
 ## AlmaLinux - can enable this for Pi 4
 #[pi4]
@@ -120,9 +122,9 @@ gpu_mem=128
 [all]
 EOF
 
-# Specific cmdline.txt files needed for raspberrypi2/3
+# Kernel command line string
 cat > /boot/cmdline.txt << EOF
-console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
+console=ttyS0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 EOF
 
 # Create and initialize swapfile

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Full guide for AlmaLinux on Raspberry Pi is available here: https://wiki.almalin
 
 ## Changelog
 
-## 2024-06-13
+## 2024-06-14
 - Enable serial console [#47](https://github.com/AlmaLinux/raspberry-pi/pull/47)
+- Install utilities for GPIO by default (AL9)
 
 ### 2024-06-05
 - Update for AlmaLinux 8.10 and 9.4

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Full guide for AlmaLinux on Raspberry Pi is available here: https://wiki.almalin
 
 ## Changelog
 
+## 2024-06-13
+- Enable serial console [#47](https://github.com/AlmaLinux/raspberry-pi/pull/47)
+
 ### 2024-06-05
 - Update for AlmaLinux 8.10 and 9.4
 - Support Raspberry Pi 5


### PR DESCRIPTION
A user reported that serial console is not working.

GPIO14 [tx], GPIO15[rx] will be used as serial console now.
