### PR TITLE
Add SElinux Autorelabel

### DIFF
--- a/kickstart/AlmaLinux-10k-RaspberryPi-console-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-10k-RaspberryPi-console-gpt.aarch64.ks
@@ -134,6 +134,10 @@ rpm --rebuilddb
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 %end
 
 %post --nochroot --erroronfail

--- a/kickstart/AlmaLinux-10k-RaspberryPi-gnome-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-10k-RaspberryPi-gnome-gpt.aarch64.ks
@@ -149,6 +149,10 @@ systemctl set-default graphical.target
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 # print disk usage
 df
 #

--- a/kickstart/AlmaLinux-8-RaspberryPi-console-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-8-RaspberryPi-console-mbr.aarch64.ks
@@ -146,6 +146,10 @@ rpm --rebuilddb
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 %end
 
 %post --nochroot --erroronfail

--- a/kickstart/AlmaLinux-8-RaspberryPi-gnome-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-8-RaspberryPi-gnome-mbr.aarch64.ks
@@ -175,6 +175,10 @@ systemctl set-default graphical.target
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 # print disk usage
 df
 #

--- a/kickstart/AlmaLinux-9-RaspberryPi-console-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-9-RaspberryPi-console-gpt.aarch64.ks
@@ -131,6 +131,10 @@ rpm --rebuilddb
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 %end
 
 %post --nochroot --erroronfail

--- a/kickstart/AlmaLinux-9-RaspberryPi-console-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-9-RaspberryPi-console-mbr.aarch64.ks
@@ -131,6 +131,10 @@ rpm --rebuilddb
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 %end
 
 %post --nochroot --erroronfail

--- a/kickstart/AlmaLinux-9-RaspberryPi-gnome-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-9-RaspberryPi-gnome-gpt.aarch64.ks
@@ -147,6 +147,10 @@ systemctl set-default graphical.target
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 # print disk usage
 df
 #

--- a/kickstart/AlmaLinux-9-RaspberryPi-gnome-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-9-RaspberryPi-gnome-mbr.aarch64.ks
@@ -147,6 +147,10 @@ systemctl set-default graphical.target
 # Remove machine-id on pre generated images
 rm -f /etc/machine-id
 touch /etc/machine-id
+
+#auto relabel SELinux
+touch /.autorelabel
+
 # print disk usage
 df
 #


### PR DESCRIPTION
it is necessary to re-label the files because an error in the selinux-policy installation when creating the image
