### PR TITLE
Fix the 'unrecognized arguments: --isUtc --nontp' error in 10 and Kitten kickstarts

### DIFF
--- a/kickstart/AlmaLinux-10-RaspberryPi-console-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-10-RaspberryPi-console-gpt.aarch64.ks
@@ -10,7 +10,7 @@ repo --name="raspberrypi" --mirrorlist="https://mirrors.almalinux.org/mirrorlist
 
 # install
 keyboard us --xlayouts=us --vckeymap=us
-timezone --isUtc --nontp UTC
+timezone --utc UTC
 selinux --enforcing
 firewall --enabled --port=22:tcp
 network --bootproto=dhcp --device=link --activate --onboot=on

--- a/kickstart/AlmaLinux-10-RaspberryPi-gnome-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-10-RaspberryPi-gnome-gpt.aarch64.ks
@@ -10,7 +10,7 @@ repo --name="raspberrypi" --mirrorlist="https://mirrors.almalinux.org/mirrorlist
 
 # install
 keyboard us --xlayouts=us --vckeymap=us
-timezone --isUtc --nontp UTC
+timezone --utc UTC
 selinux --enforcing
 firewall --enabled --port=22:tcp
 network --bootproto=dhcp --device=link --activate --onboot=on

--- a/kickstart/AlmaLinux-Kitten-10-RaspberryPi-console-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-Kitten-10-RaspberryPi-console-gpt.aarch64.ks
@@ -10,7 +10,7 @@ repo --name="raspberrypi" --mirrorlist="https://kitten.mirrors.almalinux.org/mir
 
 # install
 keyboard us --xlayouts=us --vckeymap=us
-timezone --isUtc --nontp UTC
+timezone --utc UTC
 selinux --enforcing
 firewall --enabled --port=22:tcp
 network --bootproto=dhcp --device=link --activate --onboot=on

--- a/kickstart/AlmaLinux-Kitten-10-RaspberryPi-gnome-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-Kitten-10-RaspberryPi-gnome-gpt.aarch64.ks
@@ -10,7 +10,7 @@ repo --name="raspberrypi" --mirrorlist="https://kitten.mirrors.almalinux.org/mir
 
 # install
 keyboard us --xlayouts=us --vckeymap=us
-timezone --isUtc --nontp UTC
+timezone --utc UTC
 selinux --enforcing
 firewall --enabled --port=22:tcp
 network --bootproto=dhcp --device=link --activate --onboot=on


### PR DESCRIPTION
The options have been depricated in EL9

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/kickstart-commands-and-options-reference_rhel-installer#deprecated-kickstart-comands-and-options_kickstart-changes