### PR TITLE
Update 8-th kickstarts to fix 'installing package rootfiles-8.1-22.el8.noarch needs 225MB on the / filesystem'

### DIFF
--- a/kickstart/AlmaLinux-8-RaspberryPi-console-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-8-RaspberryPi-console-mbr.aarch64.ks
@@ -22,7 +22,7 @@ lang en_US.UTF-8
 # Disk setup
 clearpart --initlabel --all
 part /boot --asprimary --fstype=vfat --size=500 --label=boot --ondisk=sda
-part / --asprimary --fstype=ext4 --size=3000 --label=rootfs --ondisk=sda
+part / --asprimary --fstype=ext4 --size=3200 --label=rootfs --ondisk=sda
 
 # Package setup
 %packages

--- a/kickstart/AlmaLinux-8-RaspberryPi-gnome-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-8-RaspberryPi-gnome-mbr.aarch64.ks
@@ -23,7 +23,7 @@ lang en_US.UTF-8
 # Disk setup
 clearpart --initlabel --all
 part /boot --asprimary --fstype=vfat --size=500 --label=boot --ondisk=sda
-part / --asprimary --fstype=ext4 --size=5000 --label=rootfs --ondisk=sda
+part / --asprimary --fstype=ext4 --size=5500 --label=rootfs --ondisk=sda
 
 # Package setup
 %packages


### PR DESCRIPTION
Increase `/` partition size for both console (to 3200MB) and gnome (to 5500Mb) images, to solve:
```
  installing package rootfiles-8.1-22.el8.noarch needs 225MB on the / filesystem

Error Summary
-------------
Disk Requirements:
   At least 225MB more space needed on the / filesystem.
```
The workflow that faces the issue: https://github.com/yuravk/raspberry-pi/actions/runs/16830233901