### PR TITLE
Exclude unnecessary firmware packages from 10 and 10-kitten

### DIFF
--- a/kickstart/AlmaLinux-10-RaspberryPi-console-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-10-RaspberryPi-console-gpt.aarch64.ks
@@ -38,6 +38,9 @@ cloud-init
 cloud-utils-growpart
 e2fsprogs
 net-tools
+-*-firmware
+brcmfmac-firmware
+linux-firmware
 linux-firmware-raspberrypi
 #linux-firmware-raspberrypi-rpi3
 raspberrypi-sys-mods

--- a/kickstart/AlmaLinux-10-RaspberryPi-gnome-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-10-RaspberryPi-gnome-gpt.aarch64.ks
@@ -45,6 +45,9 @@ cloud-init
 cloud-utils-growpart
 e2fsprogs
 net-tools
+-*-firmware
+brcmfmac-firmware
+linux-firmware
 linux-firmware-raspberrypi
 #linux-firmware-raspberrypi-rpi3
 raspberrypi-sys-mods

--- a/kickstart/AlmaLinux-Kitten-10-RaspberryPi-console-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-Kitten-10-RaspberryPi-console-gpt.aarch64.ks
@@ -38,6 +38,9 @@ cloud-init
 cloud-utils-growpart
 e2fsprogs
 net-tools
+-*-firmware
+brcmfmac-firmware
+linux-firmware
 linux-firmware-raspberrypi
 #linux-firmware-raspberrypi-rpi3
 raspberrypi-sys-mods

--- a/kickstart/AlmaLinux-Kitten-10-RaspberryPi-gnome-gpt.aarch64.ks
+++ b/kickstart/AlmaLinux-Kitten-10-RaspberryPi-gnome-gpt.aarch64.ks
@@ -45,6 +45,9 @@ cloud-init
 cloud-utils-growpart
 e2fsprogs
 net-tools
+-*-firmware
+brcmfmac-firmware
+linux-firmware
 linux-firmware-raspberrypi
 #linux-firmware-raspberrypi-rpi3
 raspberrypi-sys-mods


### PR DESCRIPTION
Packages such as amd-*-firmwares, nvidia-gpu-firmware are not necessary for RPi.

Pointed out by @FingerlessGlov3s.

-----

The following firmware packages are installed in the 10 GNOME image.
```
linux-firmware-whence-20251008-15.8.el10_0.noarch
amd-ucode-firmware-20251008-15.8.el10_0.noarch
atheros-firmware-20251008-15.8.el10_0.noarch
brcmfmac-firmware-20251008-15.8.el10_0.noarch
cirrus-audio-firmware-20251008-15.8.el10_0.noarch
intel-audio-firmware-20251008-15.8.el10_0.noarch
mt7xxx-firmware-20251008-15.8.el10_0.noarch
nxpwireless-firmware-20251008-15.8.el10_0.noarch
realtek-firmware-20251008-15.8.el10_0.noarch
tiwilink-firmware-20251008-15.8.el10_0.noarch
amd-gpu-firmware-20251008-15.8.el10_0.noarch
intel-gpu-firmware-20251008-15.8.el10_0.noarch
nvidia-gpu-firmware-20251008-15.8.el10_0.noarch
linux-firmware-20251008-15.8.el10_0.noarch
linux-firmware-raspberrypi-20240528-6.el10.noarch
raspberrypi2-firmware-6.12.47-20250916.v8.1.el10.aarch64
```