### PR TITLE
AL8: Increase rootfs size +200MB

### DIFF
--- a/kickstart/AlmaLinux-8-RaspberryPi-console-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-8-RaspberryPi-console-mbr.aarch64.ks
@@ -22,7 +22,7 @@ lang en_US.UTF-8
 # Disk setup
 clearpart --initlabel --all
 part /boot --asprimary --fstype=vfat --size=500 --label=boot --ondisk=sda
-part / --asprimary --fstype=ext4 --size=3300 --label=rootfs --ondisk=sda
+part / --asprimary --fstype=ext4 --size=3500 --label=rootfs --ondisk=sda
 
 # Package setup
 %packages

--- a/kickstart/AlmaLinux-8-RaspberryPi-gnome-mbr.aarch64.ks
+++ b/kickstart/AlmaLinux-8-RaspberryPi-gnome-mbr.aarch64.ks
@@ -23,7 +23,7 @@ lang en_US.UTF-8
 # Disk setup
 clearpart --initlabel --all
 part /boot --asprimary --fstype=vfat --size=500 --label=boot --ondisk=sda
-part / --asprimary --fstype=ext4 --size=5500 --label=rootfs --ondisk=sda
+part / --asprimary --fstype=ext4 --size=5700 --label=rootfs --ondisk=sda
 
 # Package setup
 %packages


### PR DESCRIPTION
+20MB seems to be sufficient but since the rootfs size has been gradually growing and we have already expanded it several times in the past (ex. #95), I will increase it by 200 MB.

https://github.com/AlmaLinux/raspberry-pi/actions/runs/26160336848/job/76950508676

```
Error Summary
-------------
Disk Requirements:
   At least 14MB more space needed on the / filesystem.
```